### PR TITLE
Fix _validate_content return

### DIFF
--- a/lib/JSONSchema/Validator/OAS30.pm
+++ b/lib/JSONSchema/Validator/OAS30.pm
@@ -280,7 +280,7 @@ sub _validate_content {
 
     my $content_ptr = $ptr->xget('content');
     # content in body is required but in params is optional
-    return 1, [] unless $content_ptr;
+    return 1, [], [] unless $content_ptr;
 
     my $ctype_ptr;
     if ($content_type) {


### PR DESCRIPTION
The error was `Can't use an undefined value as an ARRAY reference at /home/jcw/perl-jsonschema-validator/lib/JSONSchema/Validator/OAS30.pm line 178`, and was caused by a response having content, when the openapi spec didn't have content

This is only fixes the crash - ideally there should be an error or warning returned when the spec doesn't have any content but the response does anyway