### PR TITLE
Add expectation and actual to type mismatch errors

### DIFF
--- a/lib/JSONSchema/Validator/Constraints/Draft4.pm
+++ b/lib/JSONSchema/Validator/Constraints/Draft4.pm
@@ -85,8 +85,9 @@ sub type {
 
     return 1 if grep { $self->check_type($instance, $_) } @types;
 
+    my $actual_type = detect_type($instance);
     push @{$data->{errors}}, error(
-        message => "type mismatch",
+        message => "type mismatch (expecting any of (@types), found: $actual_type)",
         instance_path => $instance_path,
         schema_path => $schema_path
     );

--- a/lib/JSONSchema/Validator/Constraints/OAS30.pm
+++ b/lib/JSONSchema/Validator/Constraints/OAS30.pm
@@ -9,6 +9,7 @@ use Carp 'croak';
 
 use JSONSchema::Validator::JSONPointer 'json_pointer';
 use JSONSchema::Validator::Error 'error';
+use JSONSchema::Validator::Util 'detect_type';
 
 use parent 'JSONSchema::Validator::Constraints::Draft4';
 
@@ -34,8 +35,9 @@ sub type {
 
     return 1 if $result;
 
+    my $actual_type = detect_type($instance);
     push @{$data->{errors}}, error(
-        message => 'type mismatch',
+        message => "type mismatch (expecting: $type, found: $actual_type)",
         instance_path => $instance_path,
         schema_path => $schema_path
     );


### PR DESCRIPTION
As a user of the validation output, it's of great help to understand
what the library *thinks* the provided input is versus what it was
expecting it to be (without having to analyze the schema itself).