### PR TITLE
Check params from schema

### DIFF
--- a/lib/JSONSchema/Validator/OAS30.pm
+++ b/lib/JSONSchema/Validator/OAS30.pm
@@ -212,7 +212,10 @@ sub _validate_params {
     for my $type (keys %$schema_params) {
         next unless %{$schema_params->{$type}};
         # skip validation if user not specify getter for such params type
-        next unless $get_user_param->{$type};
+        if (not exists $get_user_param->{$type}) {
+            push @{$ctx->{errors}}, error(message => qq{schema specifies '$type' parameters, but '$type' parameter missing in instance data});
+            next;
+        }
         my $r = $self->_validate_type_params($ctx, $type, $schema_params->{$type}, $get_user_param->{$type});
         $result = 0 unless $r;
     }

--- a/lib/JSONSchema/Validator/OAS30.pm
+++ b/lib/JSONSchema/Validator/OAS30.pm
@@ -214,6 +214,7 @@ sub _validate_params {
         # skip validation if user not specify getter for such params type
         if (not exists $get_user_param->{$type}) {
             push @{$ctx->{errors}}, error(message => qq{schema specifies '$type' parameters, but '$type' parameter missing in instance data});
+            $result = 0;
             next;
         }
         my $r = $self->_validate_type_params($ctx, $type, $schema_params->{$type}, $get_user_param->{$type});

--- a/t/data/oas/oas30/main.json
+++ b/t/data/oas/oas30/main.json
@@ -368,6 +368,9 @@
                     ]
                 },
                 "ctype_res" : "application/json",
+                "header_res" : {
+                    "X-SERVER-sUPPoRTED-vERSIONs" : [ 2, 3 ]
+                },
 
                 "valid_req": true,
                 "valid_res": true
@@ -418,6 +421,9 @@
                     ]
                 },
                 "ctype_res" : "application/json",
+                "header_res" : {
+                    "X-SERVER-sUPPoRTED-vERSIONs" : [ 2, 3 ]
+                },
 
                 "valid_req": true,
                 "valid_res": true
@@ -468,6 +474,9 @@
                     ]
                 },
                 "ctype_res" : "application/json",
+                "header_res" : {
+                    "X-SERVER-sUPPoRTED-vERSIONs" : [ 2, 3 ]
+                },
 
                 "valid_req": false,
                 "valid_res": false
@@ -517,6 +526,9 @@
                     ]
                 },
                 "ctype_res" : "application/json",
+                "header_res" : {
+                    "X-SERVER-sUPPoRTED-vERSIONs" : [ 2, 3 ]
+                },
 
                 "valid_req": false,
                 "valid_res": false
@@ -620,6 +632,9 @@
                     ]
                 },
                 "ctype_res" : "application/json",
+                "header_res" : {
+                    "X-SERVER-sUPPoRTED-vERSIONs" : [ 2, 3 ]
+                },
 
                 "valid_req": false,
                 "valid_res": false
@@ -733,6 +748,9 @@
                     ]
                 },
                 "ctype_res" : "application/json",
+                "header_res" : {
+                    "X-SERVER-sUPPoRTED-vERSIONs" : [ 2, 3 ]
+                },
 
                 "valid_req": false,
                 "valid_res": true
@@ -869,6 +887,30 @@
 
                 "valid_req": true,
                 "valid_res": true
+            },
+
+            {
+                "description": "failure to specify \"header\" parameter fails validation on schemas that contain them; github issue 29",
+                "method" : "post",
+                "openapi_path" : "/company/{company}/pets",
+
+                "path" : {
+                    "company" : "skbkontur"
+                },
+                "query" : {
+                    "params" : "{ \"theme\" : \"butterfly\", \"offset\" : 10 }",
+                    "optional_param" : "optional",
+                    "int_param" : "123"
+                },
+                "body_req" : null,
+                "ctype_req" : "application/json",
+
+                "status" : "200",
+                "body_res" : {},
+                "ctype_res" : "application/json",
+
+                "valid_req": false,
+                "valid_res": false
             }
         ]
     }

--- a/t/oas.t
+++ b/t/oas.t
@@ -6,6 +6,7 @@ use Test::More;
 
 use lib 't/lib';
 
+use Data::Dumper;
 use Helper qw/test_dir detect_warnings/;
 use JSONSchema::Validator;
 use JSONSchema::Validator::Util qw/get_resource decode_content/;
@@ -58,8 +59,9 @@ for my $validator_class (@{$JSONSchema::Validator::OAS_VALIDATORS}) {
                     }
                 );
                 if ($t->{valid_res}) {
-                    is $result, 1, 'res: ' . $test_name;
-                    is @$errors, 0, 'res: ' . $test_name . '; errors is empty';
+                    is( $result, 1, 'res: ' . $test_name);
+                    is( @$errors, 0, 'res: ' . $test_name . '; errors is empty')
+                        or diag Dumper($errors);
                 } else {
                     is $result, 0, 'res: ' . $test_name;
                     ok @$errors > 0, 'res: ' . $test_name . '; errors is not empty';


### PR DESCRIPTION
When the schema specifies that there are requirements for header/cookie/etc parameters, and these parameters aren't provided in the instance data, return an error indicating this data is required for schema validation.

This commit unveils a condition that wasn't tested by the tests before: The validation of the `X-SERVER-sUPPoRTED-vERSIONs` header. However, its validation runs into issue #12 because its type (and test data) are of type `array`.

@avkhozov could you please indicate how you want me to resolve the currently failing tests? By changing the test case to a string? Or does #12 need to be fixed before this PR is acceptable at all? Or ...?

I've created this PR as a draft PR pending my fixes which I expect to be doing based on responses to the above questions.